### PR TITLE
Get CURR_SESSION depending on CURR_DM

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wasta-multidesktop (22.04.0.12) jammy; urgency=medium
+
+  * Make wasta-login.sh compatible with gdm.
+
+ -- Nate Marti <nate_marti@sil.org>  Wed, 30 Mar 2022 18:17:48 +0100
+
 wasta-multidesktop (22.04.0.11) jammy; urgency=medium
 
   * Fix gdm3 package name.


### PR DESCRIPTION
wasta-login.sh currently relies on the "Desktop" property from `loginctl show-session`, but this property is not set when gdm is the display manager. So instead, this change has wasta-login.sh determine the CURR_DM first, then determine the CURR_SESSION based on which DM is in use. I dropped the script into a VM running Wasta focal+lightdm+cinnamon and it worked fine, not that it really needs to be updated for focal, but it's at least compatible. I tested this update in Ubuntu jammy+gdm+ubuntu and it worked fine there, too.